### PR TITLE
James-gatling 69 :  fix jmap get messages

### DIFF
--- a/src/it/scala-2.12/org/apache/james/gatling/imap/ImapAuthenticationIT.scala
+++ b/src/it/scala-2.12/org/apache/james/gatling/imap/ImapAuthenticationIT.scala
@@ -1,4 +1,4 @@
-package org.apache.james.gatling
+package org.apache.james.gatling.imap
 
 import org.apache.james.gatling.imap.scenari.ImapAuthenticationScenario
 

--- a/src/it/scala-2.12/org/apache/james/gatling/imap/ImapFullIT.scala
+++ b/src/it/scala-2.12/org/apache/james/gatling/imap/ImapFullIT.scala
@@ -1,6 +1,8 @@
-package org.apache.james.gatling
+package org.apache.james.gatling.imap
 
+import org.apache.james.gatling.Fixture
 import org.apache.james.gatling.imap.scenari.ImapFullScenario
+
 import scala.concurrent.duration._
 
 class ImapFullIT extends ImapIT {

--- a/src/it/scala-2.12/org/apache/james/gatling/imap/ImapIT.scala
+++ b/src/it/scala-2.12/org/apache/james/gatling/imap/ImapIT.scala
@@ -1,24 +1,25 @@
-package org.apache.james.gatling
+package org.apache.james.gatling.imap
 
+import com.linagora.gatling.imap.protocol.ImapProtocolBuilder
 import io.gatling.core.Predef._
 import io.gatling.core.feeder.FeederBuilder
 import io.gatling.core.funspec.GatlingFunSpec
 import io.gatling.core.protocol.Protocol
 import io.gatling.core.structure.ScenarioBuilder
 import org.apache.james.gatling.Fixture.{bart, simpsonDomain}
+import org.apache.james.gatling.JamesServer
 import org.apache.james.gatling.JamesServer.RunningServer
 import org.apache.james.gatling.control.UserFeeder
-import org.apache.james.gatling.smtp.SmtpProtocol
 import org.slf4j
 import org.slf4j.LoggerFactory
 
-abstract class SmtpIT extends GatlingFunSpec {
+abstract class ImapIT extends GatlingFunSpec {
   protected val logger: slf4j.Logger = LoggerFactory.getLogger(this.getClass.getCanonicalName)
 
   protected val server: RunningServer = JamesServer.start()
-  lazy val protocolConf: Protocol = new SmtpProtocol("localhost", false, mappedSmtpPort, false)
+  lazy val protocolConf: Protocol = new ImapProtocolBuilder("localhost", mappedImapPort).build()
 
-  protected def mappedSmtpPort = server.mappedSmtpPort
+  protected def mappedImapPort = server.mappedImapPort
 
   protected lazy val users = List(bart)
 

--- a/src/it/scala-2.12/org/apache/james/gatling/imap/ImapListMessagesBodyStructureIT.scala
+++ b/src/it/scala-2.12/org/apache/james/gatling/imap/ImapListMessagesBodyStructureIT.scala
@@ -1,10 +1,11 @@
-package org.apache.james.gatling
+package org.apache.james.gatling.imap
 
+import org.apache.james.gatling.Fixture
 import org.apache.james.gatling.imap.scenari.ImapListMessagesBodyStructureScenario
 import org.apache.james.gatling.jmap.MailboxName
 
-import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 
 

--- a/src/it/scala-2.12/org/apache/james/gatling/imap/ImapStoreIT.scala
+++ b/src/it/scala-2.12/org/apache/james/gatling/imap/ImapStoreIT.scala
@@ -1,6 +1,8 @@
-package org.apache.james.gatling
+package org.apache.james.gatling.imap
 
+import org.apache.james.gatling.Fixture
 import org.apache.james.gatling.imap.scenari.ImapStoreScenario
+
 import scala.concurrent.duration._
 
 class ImapStoreIT extends ImapIT {

--- a/src/it/scala-2.12/org/apache/james/gatling/jmap/JmapAllIT.scala
+++ b/src/it/scala-2.12/org/apache/james/gatling/jmap/JmapAllIT.scala
@@ -1,5 +1,6 @@
-package org.apache.james.gatling
+package org.apache.james.gatling.jmap
 
+import org.apache.james.gatling.Fixture
 import org.apache.james.gatling.jmap.scenari.JmapAllScenario
 
 import scala.concurrent.duration._

--- a/src/it/scala-2.12/org/apache/james/gatling/jmap/JmapAllScenarioIT.scala
+++ b/src/it/scala-2.12/org/apache/james/gatling/jmap/JmapAllScenarioIT.scala
@@ -1,4 +1,4 @@
-package org.apache.james.gatling
+package org.apache.james.gatling.jmap
 
 import org.apache.james.gatling.jmap.scenari.JmapAllScenario
 

--- a/src/it/scala-2.12/org/apache/james/gatling/jmap/JmapAuthenticationIT.scala
+++ b/src/it/scala-2.12/org/apache/james/gatling/jmap/JmapAuthenticationIT.scala
@@ -1,4 +1,4 @@
-package org.apache.james.gatling
+package org.apache.james.gatling.jmap
 
 import org.apache.james.gatling.jmap.scenari.JmapAuthenticationScenario
 

--- a/src/it/scala-2.12/org/apache/james/gatling/jmap/JmapBigSetIT.scala
+++ b/src/it/scala-2.12/org/apache/james/gatling/jmap/JmapBigSetIT.scala
@@ -1,5 +1,6 @@
-package org.apache.james.gatling
+package org.apache.james.gatling.jmap
 
+import org.apache.james.gatling.Fixture
 import org.apache.james.gatling.jmap.scenari.JmapBigSetScenario
 
 import scala.concurrent.duration._

--- a/src/it/scala-2.12/org/apache/james/gatling/jmap/JmapCountMailboxesIT.scala
+++ b/src/it/scala-2.12/org/apache/james/gatling/jmap/JmapCountMailboxesIT.scala
@@ -1,5 +1,6 @@
-package org.apache.james.gatling
+package org.apache.james.gatling.jmap
 
+import org.apache.james.gatling.Fixture
 import org.apache.james.gatling.jmap.scenari.JmapCountMailboxesScenario
 
 import scala.concurrent.duration._

--- a/src/it/scala-2.12/org/apache/james/gatling/jmap/JmapGetMailboxesIT.scala
+++ b/src/it/scala-2.12/org/apache/james/gatling/jmap/JmapGetMailboxesIT.scala
@@ -1,5 +1,6 @@
-package org.apache.james.gatling
+package org.apache.james.gatling.jmap
 
+import org.apache.james.gatling.Fixture
 import org.apache.james.gatling.jmap.scenari.JmapGetMailboxesScenario
 
 import scala.concurrent.duration._

--- a/src/it/scala-2.12/org/apache/james/gatling/jmap/JmapGetMessageListIT.scala
+++ b/src/it/scala-2.12/org/apache/james/gatling/jmap/JmapGetMessageListIT.scala
@@ -1,5 +1,6 @@
-package org.apache.james.gatling
+package org.apache.james.gatling.jmap
 
+import org.apache.james.gatling.Fixture
 import org.apache.james.gatling.jmap.scenari.JmapGetMessageListScenario
 
 import scala.concurrent.duration._

--- a/src/it/scala-2.12/org/apache/james/gatling/jmap/JmapGetMessagesIT.scala
+++ b/src/it/scala-2.12/org/apache/james/gatling/jmap/JmapGetMessagesIT.scala
@@ -1,5 +1,6 @@
-package org.apache.james.gatling
+package org.apache.james.gatling.jmap
 
+import org.apache.james.gatling.Fixture
 import org.apache.james.gatling.jmap.scenari.JmapGetMessagesScenario
 
 import scala.concurrent.duration._

--- a/src/it/scala-2.12/org/apache/james/gatling/jmap/JmapIT.scala
+++ b/src/it/scala-2.12/org/apache/james/gatling/jmap/JmapIT.scala
@@ -1,4 +1,4 @@
-package org.apache.james.gatling
+package org.apache.james.gatling.jmap
 
 import io.gatling.core.Predef._
 import io.gatling.core.funspec.GatlingFunSpec
@@ -6,6 +6,7 @@ import io.gatling.core.protocol.Protocol
 import io.gatling.core.structure.ScenarioBuilder
 import io.gatling.http.Predef._
 import org.apache.james.gatling.Fixture.{bart, simpsonDomain}
+import org.apache.james.gatling.JamesServer
 import org.apache.james.gatling.JamesServer.RunningServer
 import org.apache.james.gatling.control.RecipientFeeder.RecipientFeederBuilder
 import org.apache.james.gatling.control.UserFeeder.UserFeederBuilder

--- a/src/it/scala-2.12/org/apache/james/gatling/jmap/JmapInboxHomeLoadingIT.scala
+++ b/src/it/scala-2.12/org/apache/james/gatling/jmap/JmapInboxHomeLoadingIT.scala
@@ -1,5 +1,6 @@
-package org.apache.james.gatling
+package org.apache.james.gatling.jmap
 
+import org.apache.james.gatling.Fixture
 import org.apache.james.gatling.jmap.scenari.JmapInboxHomeLoadingScenario
 
 class JmapInboxHomeLoadingIT extends JmapIT {

--- a/src/it/scala-2.12/org/apache/james/gatling/jmap/JmapMessageUpdateIT.scala
+++ b/src/it/scala-2.12/org/apache/james/gatling/jmap/JmapMessageUpdateIT.scala
@@ -1,5 +1,6 @@
-package org.apache.james.gatling
+package org.apache.james.gatling.jmap
 
+import org.apache.james.gatling.Fixture
 import org.apache.james.gatling.jmap.scenari.JmapMessageUpdateScenario
 
 import scala.concurrent.duration._

--- a/src/it/scala-2.12/org/apache/james/gatling/jmap/JmapOpenArbitraryMessageIT.scala
+++ b/src/it/scala-2.12/org/apache/james/gatling/jmap/JmapOpenArbitraryMessageIT.scala
@@ -1,5 +1,6 @@
-package org.apache.james.gatling
+package org.apache.james.gatling.jmap
 
+import org.apache.james.gatling.Fixture
 import org.apache.james.gatling.jmap.scenari.JmapOpenArbitraryMessageScenario
 
 class JmapOpenArbitraryMessageIT extends JmapIT {

--- a/src/it/scala-2.12/org/apache/james/gatling/jmap/JmapQueueBrowseIT.scala
+++ b/src/it/scala-2.12/org/apache/james/gatling/jmap/JmapQueueBrowseIT.scala
@@ -1,5 +1,6 @@
-package org.apache.james.gatling
+package org.apache.james.gatling.jmap
 
+import org.apache.james.gatling.Fixture
 import org.apache.james.gatling.control.JamesWebAdministrationQuery
 import org.apache.james.gatling.jmap.scenari.JmapQueueBrowseScenario
 

--- a/src/it/scala-2.12/org/apache/james/gatling/jmap/JmapSelectArbitraryMailboxIT.scala
+++ b/src/it/scala-2.12/org/apache/james/gatling/jmap/JmapSelectArbitraryMailboxIT.scala
@@ -1,5 +1,6 @@
-package org.apache.james.gatling
+package org.apache.james.gatling.jmap
 
+import org.apache.james.gatling.Fixture
 import org.apache.james.gatling.jmap.scenari.JmapSelectArbitraryMaiboxScenario
 
 class JmapSelectArbitraryMailboxIT extends JmapIT {

--- a/src/it/scala-2.12/org/apache/james/gatling/jmap/JmapSendMessagesIT.scala
+++ b/src/it/scala-2.12/org/apache/james/gatling/jmap/JmapSendMessagesIT.scala
@@ -1,5 +1,6 @@
-package org.apache.james.gatling
+package org.apache.james.gatling.jmap
 
+import org.apache.james.gatling.Fixture
 import org.apache.james.gatling.jmap.scenari.JmapSendMessagesScenario
 
 import scala.concurrent.duration._

--- a/src/it/scala-2.12/org/apache/james/gatling/jmap/test/JmapVerifyNoErrorCheckBehaviourIT.scala
+++ b/src/it/scala-2.12/org/apache/james/gatling/jmap/test/JmapVerifyNoErrorCheckBehaviourIT.scala
@@ -1,0 +1,50 @@
+package org.apache.james.gatling.jmap.test
+
+import io.gatling.core.Predef._
+import io.gatling.core.structure.ScenarioBuilder
+import io.gatling.http.check.HttpCheck
+import org.apache.james.gatling.Fixture
+import org.apache.james.gatling.control.RecipientFeeder.RecipientFeederBuilder
+import org.apache.james.gatling.control.UserFeeder.UserFeederBuilder
+import org.apache.james.gatling.jmap.JmapMessages.typicalMessageProperties
+import org.apache.james.gatling.jmap.RetryAuthentication.execWithRetryAuthentication
+import org.apache.james.gatling.jmap._
+
+import scala.concurrent.duration._
+
+class JmapVerifyNoErrorCheckBehaviourIT extends JmapIT {
+  private val MAILS_NUMBER = 1
+
+  before {
+    users.foreach(server.sendMessage(Fixture.homer.username))
+  }
+
+  private def bogusGetRandomMessage(properties: List[String] = typicalMessageProperties, messageIdsKey: String = "messageIds") =
+    JmapAuthentication.authenticatedQuery("getMessages (with bogus properties serialization)", "/jmap")
+      .body(StringBody(
+        s"""[[
+          "getMessages",
+          {
+            "ids": ["$${$messageIdsKey.random()}"],
+            "properties": [[]]
+          },
+          "#0"
+          ]]"""))
+
+  private def generate(duration: Duration, userFeeder: UserFeederBuilder, recipientFeeder: RecipientFeederBuilder, randomlySentMails: Int): ScenarioBuilder = {
+    import io.gatling.http.Predef._
+    val noErrorCheck: Seq[HttpCheck] = List(JmapChecks.noError)
+    val hasErrorCheck: Seq[HttpCheck] = List(JmapChecks.hasError)
+
+    io.gatling.core.Predef.scenario("JmapGetMessages")
+      .feed(userFeeder)
+      .exec(CommonSteps.provisionUsersWithMessageList(recipientFeeder, randomlySentMails))
+      .exec(execWithRetryAuthentication(JmapMessages.getRandomMessage(), noErrorCheck))
+      .exec(execWithRetryAuthentication(bogusGetRandomMessage(), hasErrorCheck))
+  }
+
+  scenario((userFeederBuilder, recipientFeederBuilder) => {
+    generate(10 seconds, userFeederBuilder, recipientFeederBuilder, MAILS_NUMBER)
+  })
+
+}

--- a/src/it/scala-2.12/org/apache/james/gatling/smtp/SmtpIT.scala
+++ b/src/it/scala-2.12/org/apache/james/gatling/smtp/SmtpIT.scala
@@ -1,24 +1,24 @@
-package org.apache.james.gatling
+package org.apache.james.gatling.smtp
 
-import com.linagora.gatling.imap.protocol.ImapProtocolBuilder
 import io.gatling.core.Predef._
 import io.gatling.core.feeder.FeederBuilder
 import io.gatling.core.funspec.GatlingFunSpec
 import io.gatling.core.protocol.Protocol
 import io.gatling.core.structure.ScenarioBuilder
 import org.apache.james.gatling.Fixture.{bart, simpsonDomain}
+import org.apache.james.gatling.JamesServer
 import org.apache.james.gatling.JamesServer.RunningServer
 import org.apache.james.gatling.control.UserFeeder
 import org.slf4j
 import org.slf4j.LoggerFactory
 
-abstract class ImapIT extends GatlingFunSpec {
+abstract class SmtpIT extends GatlingFunSpec {
   protected val logger: slf4j.Logger = LoggerFactory.getLogger(this.getClass.getCanonicalName)
 
   protected val server: RunningServer = JamesServer.start()
-  lazy val protocolConf: Protocol = new ImapProtocolBuilder("localhost", mappedImapPort).build()
+  lazy val protocolConf: Protocol = new SmtpProtocol("localhost", false, mappedSmtpPort, false)
 
-  protected def mappedImapPort = server.mappedImapPort
+  protected def mappedSmtpPort = server.mappedSmtpPort
 
   protected lazy val users = List(bart)
 

--- a/src/main/scala-2.12/org/apache/james/gatling/jmap/JmapChecks.scala
+++ b/src/main/scala-2.12/org/apache/james/gatling/jmap/JmapChecks.scala
@@ -1,10 +1,14 @@
 package org.apache.james.gatling.jmap
 
 import io.gatling.core.Predef._
+import io.gatling.core.check.extractor.jsonpath.{JsonPathCheckBuilder, JsonPathOfType}
 
 object JmapChecks {
 
-  val noError = jsonPath("$.error").notExists
+  private val hasErrorPath: JsonPathCheckBuilder[String] with JsonPathOfType = jsonPath("$[?(@[0] == 'error')]")
+
+  val noError = hasErrorPath.notExists
+  val hasError = hasErrorPath.exists
 
   def created() = jsonPath(s"$$[0][1].created['$${${JmapMessages.messageIdSessionParam}}'].id").exists
 

--- a/src/main/scala-2.12/org/apache/james/gatling/jmap/JmapMessages.scala
+++ b/src/main/scala-2.12/org/apache/james/gatling/jmap/JmapMessages.scala
@@ -175,7 +175,7 @@ object JmapMessages {
           "getMessages",
           {
             "ids": ["$${$messageIdsKey.random()}"],
-            "properties": [ ${Json.stringify(properties)} ]
+            "properties": ${Json.stringify(properties)}
           },
           "#0"
           ]]"""))
@@ -188,7 +188,7 @@ object JmapMessages {
           "getMessages",
           {
             "ids": $${$messageIdsKey.jsonStringify()},
-            "properties": [ ${Json.stringify(properties)} ]
+            "properties": ${Json.stringify(properties)}
           },
           "#0"
           ]]"""))


### PR DESCRIPTION
getMessages has currently two related issues:

    first defining properties like "properties": [ ${Json.stringify(properties)} ] make a json array of a json array, instead of a json array. Consequence: the JMAP request cannot be parsed, and the server errors it
    second JmapChecks.noError does not detect the error returned in this case, which is nevertheless a perfectly valid JMAP error [["error", etc.]]

https://github.com/linagora/james-gatling/issues/69
