### PR TITLE
Open injection fixup

### DIFF
--- a/src/test/scala-2.12/org/apache/james/gatling/simulation/Injection.scala
+++ b/src/test/scala-2.12/org/apache/james/gatling/simulation/Injection.scala
@@ -9,8 +9,8 @@ abstract sealed class UsersDensity {
   def injectDuring(givenDuring: FiniteDuration): OpenInjectionStep
 }
 case class UsersPerHour(nb: Double) extends UsersDensity {
-  private def usersPerSecForDuration(givenDuring: FiniteDuration): Double = nb * givenDuring.toSeconds / 1.hour.toSeconds
-  override def injectDuring(givenDuring: FiniteDuration): ConstantRateOpenInjection = constantUsersPerSec(usersPerSecForDuration(givenDuring)) during givenDuring
+  private def usersPerSecForDuration(): Double = nb / 1.hour.toSeconds
+  override def injectDuring(givenDuring: FiniteDuration): ConstantRateOpenInjection = constantUsersPerSec(usersPerSecForDuration()) during givenDuring
 }
 case class UsersTotal(nb: Double) extends UsersDensity {
   override def injectDuring(givenDuring: FiniteDuration): RampOpenInjection = rampUsers(nb.toInt) during givenDuring

--- a/src/test/scala-2.12/org/apache/james/gatling/simulation/Injection.scala
+++ b/src/test/scala-2.12/org/apache/james/gatling/simulation/Injection.scala
@@ -9,8 +9,8 @@ abstract sealed class UsersDensity {
   def injectDuring(givenDuring: FiniteDuration): OpenInjectionStep
 }
 case class UsersPerHour(nb: Double) extends UsersDensity {
-  private def usersPerSecForDuration: Double = nb / 1.hour.toSeconds
-  override def injectDuring(givenDuring: FiniteDuration): ConstantRateOpenInjection = constantUsersPerSec(usersPerSecForDuration) during givenDuring
+  private def usersPerSecForDuration(givenDuring: FiniteDuration): Double = nb / givenDuring.toSeconds
+  override def injectDuring(givenDuring: FiniteDuration): ConstantRateOpenInjection = constantUsersPerSec(usersPerSecForDuration(givenDuring)) during givenDuring
 }
 case class UsersTotal(nb: Double) extends UsersDensity {
   override def injectDuring(givenDuring: FiniteDuration): RampOpenInjection = rampUsers(nb.toInt) during givenDuring

--- a/src/test/scala-2.12/org/apache/james/gatling/simulation/Injection.scala
+++ b/src/test/scala-2.12/org/apache/james/gatling/simulation/Injection.scala
@@ -9,8 +9,8 @@ abstract sealed class UsersDensity {
   def injectDuring(givenDuring: FiniteDuration): OpenInjectionStep
 }
 case class UsersPerHour(nb: Double) extends UsersDensity {
-  private def usersPerSecForDuration(): Double = nb / 1.hour.toSeconds
-  override def injectDuring(givenDuring: FiniteDuration): ConstantRateOpenInjection = constantUsersPerSec(usersPerSecForDuration()) during givenDuring
+  private def usersPerSecForDuration: Double = nb / 1.hour.toSeconds
+  override def injectDuring(givenDuring: FiniteDuration): ConstantRateOpenInjection = constantUsersPerSec(usersPerSecForDuration) during givenDuring
 }
 case class UsersTotal(nb: Double) extends UsersDensity {
   override def injectDuring(givenDuring: FiniteDuration): RampOpenInjection = rampUsers(nb.toInt) during givenDuring


### PR DESCRIPTION
So before #76 changes, for the simulations injecting a fixed amount of users per second, we had around 13 (I did the math :) ).

With default values of 50000 users and a duration of one hour, and one hour being 3600 seconds we were doing `50000 / 3600 = 13.8 users injected per seconds`

Well after the update it became `50000 * 3600 / 3600 = 50000 users injected per seconds`

No wonder charge-01 was out of memory in less than a minute when I tried to run those :trollface: 