### PR TITLE
JAMES-3028 Fix the constant number of users being injected for corpus…

### DIFF
--- a/src/test/scala-2.12/org/apache/james/gatling/simulation/Configuration.scala
+++ b/src/test/scala-2.12/org/apache/james/gatling/simulation/Configuration.scala
@@ -21,7 +21,7 @@ object Configuration {
   val BaseJamesWebAdministrationUrl = new URL(s"$WEBADMIN_PROTOCOL://$WebadminServerHostName:$WEBADMIN_PORT")
 
   val ScenarioDuration = 1 hour
-  val InjectionDuration = 5 minutes
+  val InjectionDuration = 1 hour
   val UserCount = 100
   val RandomlySentMails = 10
   val NumberOfMailboxes = 10

--- a/src/test/scala-2.12/org/apache/james/gatling/simulation/Injection.scala
+++ b/src/test/scala-2.12/org/apache/james/gatling/simulation/Injection.scala
@@ -10,8 +10,8 @@ abstract sealed class UsersDensity {
 }
 case class UsersPerHour(nb: Double) extends UsersDensity {
   private val ONE_HOUR: Duration = 1 hour
-  private def usersPerSecForDuration: Double = nb / ONE_HOUR.toSeconds
-  override def injectDuring(givenDuring: FiniteDuration): ConstantRateOpenInjection = constantUsersPerSec(usersPerSecForDuration) during givenDuring
+  private val usersPerSec: Double = nb / ONE_HOUR.toSeconds
+  override def injectDuring(givenDuring: FiniteDuration): ConstantRateOpenInjection = constantUsersPerSec(usersPerSec) during givenDuring
 }
 case class UsersPerSecond(nb: Double) extends UsersDensity {
   override def injectDuring(givenDuring: FiniteDuration): ConstantRateOpenInjection = constantUsersPerSec(nb) during givenDuring

--- a/src/test/scala-2.12/org/apache/james/gatling/simulation/Injection.scala
+++ b/src/test/scala-2.12/org/apache/james/gatling/simulation/Injection.scala
@@ -8,9 +8,13 @@ import scala.concurrent.duration._
 abstract sealed class UsersDensity {
   def injectDuring(givenDuring: FiniteDuration): OpenInjectionStep
 }
+case class UsersPerHour(nb: Double) extends UsersDensity {
+  private val ONE_HOUR: Duration = 1 hour
+  private def usersPerSecForDuration: Double = nb / ONE_HOUR.toSeconds
+  override def injectDuring(givenDuring: FiniteDuration): ConstantRateOpenInjection = constantUsersPerSec(usersPerSecForDuration) during givenDuring
+}
 case class UsersPerSecond(nb: Double) extends UsersDensity {
-  private def usersPerSecForDuration(givenDuring: FiniteDuration): Double = nb / givenDuring.toSeconds
-  override def injectDuring(givenDuring: FiniteDuration): ConstantRateOpenInjection = constantUsersPerSec(usersPerSecForDuration(givenDuring)) during givenDuring
+  override def injectDuring(givenDuring: FiniteDuration): ConstantRateOpenInjection = constantUsersPerSec(nb) during givenDuring
 }
 case class UsersTotal(nb: Double) extends UsersDensity {
   override def injectDuring(givenDuring: FiniteDuration): RampOpenInjection = rampUsers(nb.toInt) during givenDuring

--- a/src/test/scala-2.12/org/apache/james/gatling/simulation/Injection.scala
+++ b/src/test/scala-2.12/org/apache/james/gatling/simulation/Injection.scala
@@ -8,7 +8,7 @@ import scala.concurrent.duration._
 abstract sealed class UsersDensity {
   def injectDuring(givenDuring: FiniteDuration): OpenInjectionStep
 }
-case class UsersPerHour(nb: Double) extends UsersDensity {
+case class UsersPerSecond(nb: Double) extends UsersDensity {
   private def usersPerSecForDuration(givenDuring: FiniteDuration): Double = nb / givenDuring.toSeconds
   override def injectDuring(givenDuring: FiniteDuration): ConstantRateOpenInjection = constantUsersPerSec(usersPerSecForDuration(givenDuring)) during givenDuring
 }

--- a/src/test/scala-2.12/org/apache/james/gatling/simulation/SimulationOnMailCorpus.scala
+++ b/src/test/scala-2.12/org/apache/james/gatling/simulation/SimulationOnMailCorpus.scala
@@ -27,7 +27,7 @@ trait SimulationOnMailCorpus {
 
   protected val feeder: SourceFeederBuilder[String] = UserFeeder.toFeeder(getUsers).circular
 
-  protected def injectUsersInScenario(scenario: ScenarioBuilder, nbUsers: UsersDensity = UsersPerHour(50000)) = {
+  protected def injectUsersInScenario(scenario: ScenarioBuilder, nbUsers: UsersDensity = UsersPerSecond(50000)) = {
     scenario
       .inject(nbUsers.injectDuring(Configuration.InjectionDuration))
       .protocols(HttpSettings.httpProtocol)

--- a/src/test/scala-2.12/org/apache/james/gatling/simulation/SimulationOnMailCorpus.scala
+++ b/src/test/scala-2.12/org/apache/james/gatling/simulation/SimulationOnMailCorpus.scala
@@ -27,7 +27,7 @@ trait SimulationOnMailCorpus {
 
   protected val feeder: SourceFeederBuilder[String] = UserFeeder.toFeeder(getUsers).circular
 
-  protected def injectUsersInScenario(scenario: ScenarioBuilder, nbUsers: UsersDensity = UsersPerSecond(5)) = {
+  protected def injectUsersInScenario(scenario: ScenarioBuilder, nbUsers: UsersDensity = UsersPerSecond(3)) = {
     scenario
       .inject(nbUsers.injectDuring(Configuration.InjectionDuration))
       .protocols(HttpSettings.httpProtocol)

--- a/src/test/scala-2.12/org/apache/james/gatling/simulation/SimulationOnMailCorpus.scala
+++ b/src/test/scala-2.12/org/apache/james/gatling/simulation/SimulationOnMailCorpus.scala
@@ -27,7 +27,7 @@ trait SimulationOnMailCorpus {
 
   protected val feeder: SourceFeederBuilder[String] = UserFeeder.toFeeder(getUsers).circular
 
-  protected def injectUsersInScenario(scenario: ScenarioBuilder, nbUsers: UsersDensity = UsersPerSecond(50000)) = {
+  protected def injectUsersInScenario(scenario: ScenarioBuilder, nbUsers: UsersDensity = UsersPerSecond(5)) = {
     scenario
       .inject(nbUsers.injectDuring(Configuration.InjectionDuration))
       .protocols(HttpSettings.httpProtocol)


### PR DESCRIPTION
… simulations and the injection duration

We had Gatling simulation trying to inject around 166 users per second for a duration of just 5 minutes... This was unrealistic.

This will allow to inject instead around 14 users per second for a duration of an hour.

Not the first time I fix this rate BTW...