### PR TITLE
[FIX] Authentication management: better handle timeouts and missing v…

### DIFF
--- a/src/main/scala-2.12/org/apache/james/gatling/jmap/draft/RetryAuthentication.scala
+++ b/src/main/scala-2.12/org/apache/james/gatling/jmap/draft/RetryAuthentication.scala
@@ -9,10 +9,11 @@ import io.gatling.http.request.builder.HttpRequestBuilder.toActionBuilder
 import io.gatling.http.response.Response
 
 object RetryAuthentication {
+  val undefined = 900
 
   def execWithRetryAuthentication(scenario: HttpRequestBuilder, checks: Seq[HttpCheck]): ChainBuilder =
     doIf(session => !session.attributes.contains("accessTokenHeader")) {JmapAuthentication.authentication()}
-      .exec(session => session.set("statusCode", 900))
+      .exec(session => session.set("statusCode", undefined)) // setup a default statusCode for it to be positioned in case of timeouts
       .exec(scenario.check(status.in(200, 401).saveAs("statusCode")).check(checkIfOk(checks): _*))
       .doIfEquals("${statusCode}", 401){
           JmapAuthentication.authentication()


### PR DESCRIPTION
…ariables

 - statusCodes are not defined upon timeouts which let to crashes while checking auth
 - Missing authentication tokens should trigger auth prior optimistic execution

 Undefined session variables led to scenarii crashes / bad interpretations. With
 the current fix, we avoid further errors upon timeouts and better handle missing
 session variables.