### PR TITLE
ISSUE-105 Fix config wsBaseUrl

### DIFF
--- a/src/test/scala-2.12/org/apache/james/gatling/simulation/Configuration.scala
+++ b/src/test/scala-2.12/org/apache/james/gatling/simulation/Configuration.scala
@@ -14,7 +14,10 @@ object Configuration {
 
   val JMAP_PORT = Properties.envOrElse("JMAP_PORT", "1080").toInt
   val JMAP_PROTOCOL = Properties.envOrElse("JMAP_PROTOCOL", "http")
+  val WS_PROTOCOL = Properties.envOrElse("WS_PROTOCOL", "ws")
+  val WS_PORT = Properties.envOrElse("WS_PORT", String.valueOf(JMAP_PORT)).toInt
   val BaseJmapUrl = new URL(s"$JMAP_PROTOCOL://$JmapServerHostName:$JMAP_PORT")
+  val BaseWsUrl = s"$WS_PROTOCOL://$JmapServerHostName:$WS_PORT"
 
   val WEBADMIN_PORT = Properties.envOrElse("WEBADMIN_PORT", "8000").toInt
   val WEBADMIN_PROTOCOL = Properties.envOrElse("WEBADMIN_PROTOCOL", "http")

--- a/src/test/scala-2.12/org/apache/james/gatling/simulation/HttpSettings.scala
+++ b/src/test/scala-2.12/org/apache/james/gatling/simulation/HttpSettings.scala
@@ -10,6 +10,6 @@ object HttpSettings {
     .baseUrl(Configuration.BaseJmapUrl.toString)
     .acceptHeader(JmapHttp.ACCEPT_JSON_VALUE)
     .contentTypeHeader(JmapHttp.CONTENT_TYPE_JSON_VALUE)
-    .wsBaseUrl(Configuration.BaseJmapUrl.toString)
+    .wsBaseUrl(Configuration.BaseWsUrl)
 
 }


### PR DESCRIPTION
Relate to https://github.com/linagora/james-gatling/pull/105

When simulation to James external server. Websocket can't handshake.

**Reason:**
`.wsBaseUrl` is using `http` protocol. 
 
**How to fix:**
Re-declare an endpoint wsBaseUrl, that using `ws/wss` protocol in prefix.