### PR TITLE
Force netty-tcnative-boringssl-static to 2.0.45.Final

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,4 @@ scalacOptions in ThisBuild ++= Seq("-unchecked", "-deprecation", "-feature", "-l
 
 enablePlugins(GatlingPlugin)
 
-resolvers += "lightshed-maven" at "http://dl.bintray.com/content/lightshed/maven"
-resolvers += "Fabricator" at "http://dl.bintray.com/biercoff/Fabricator"
-
 lazy val gatlingImap = ProjectRef(uri("https://github.com/linagora/gatling-imap.git"), "gatling-imap")

--- a/build.sbt
+++ b/build.sbt
@@ -13,6 +13,9 @@ lazy val root = (project in file("."))
 
       libraryDependencies += "com.github.azakordonets" %% "fabricator" % "2.1.5",
 
+      // Temporary fix for netty version clashes between gatling and imapnio libs
+      libraryDependencies += "io.netty" % "netty-tcnative-boringssl-static" % "2.0.45.Final",
+
       // Dependencies for local Courier library
       libraryDependencies += "com.sun.mail" % "javax.mail" % "1.6.2",
       libraryDependencies += "javax.activation" % "activation" % "1.1.1",


### PR DESCRIPTION
When upgrading the lib imapnio-core to 4.3.7 on gatling-imap submodule, it creates an issue in james-gatling.

It can't find SSLPrivateKeyMethod, because Gatling is using it through an older version of Netty than imapnio. Forcing an upgrade on it seems to solve it for now.

But we should upgrade our Gatling lib at some point...

This goes together with https://github.com/linagora/gatling-imap/pull/54