### PR TITLE
Fix gatling-imap submodule fetch

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,4 +31,4 @@ enablePlugins(GatlingPlugin)
 resolvers += "lightshed-maven" at "http://dl.bintray.com/content/lightshed/maven"
 resolvers += "Fabricator" at "http://dl.bintray.com/biercoff/Fabricator"
 
-lazy val gatlingImap = ProjectRef(uri("git://github.com/linagora/gatling-imap.git"), "gatling-imap")
+lazy val gatlingImap = ProjectRef(uri("https://github.com/linagora/gatling-imap.git"), "gatling-imap")


### PR DESCRIPTION
Since 15th of march 2022, fetching git code using unauthenticated git (git://) is not supported anymore: https://github.blog/2021-09-01-improving-git-protocol-security-github/

It's better to switch to an https uri anyway

Tested successfully locally