### PR TITLE
Remove default headers in Http protocol definition

### DIFF
--- a/src/main/scala-2.12/org/apache/james/gatling/jmap/rfc8621/JmapHttp.scala
+++ b/src/main/scala-2.12/org/apache/james/gatling/jmap/rfc8621/JmapHttp.scala
@@ -4,15 +4,16 @@ import com.fasterxml.jackson.databind.JsonNode
 import io.gatling.core.Predef._
 import io.gatling.core.check.MultipleFindCheckBuilder
 import io.gatling.core.check.jsonpath.{JsonPathCheckType, JsonPathOfType}
+import io.gatling.http.HeaderNames
 import io.gatling.http.Predef.{http, status}
 import io.gatling.http.request.builder.HttpRequestBuilder
 
 
 object JmapHttp {
-  val CONTENT_TYPE_JSON_KEY: String = "Content-Type"
+  val CONTENT_TYPE_JSON_KEY: String = HeaderNames.ContentType.toString
   val CONTENT_TYPE_JSON_VALUE: String = "application/json; charset=UTF-8"
 
-  val ACCEPT_JSON_KEY: String = "Accept"
+  val ACCEPT_JSON_KEY: String = HeaderNames.Accept.toString
   val ACCEPT_JSON_VALUE: String = "application/json; jmapVersion=rfc-8621"
 
   val HEADERS_JSON = Map(CONTENT_TYPE_JSON_KEY -> CONTENT_TYPE_JSON_VALUE, ACCEPT_JSON_KEY -> ACCEPT_JSON_VALUE)

--- a/src/test/scala-2.12/org/apache/james/gatling/simulation/HttpSettings.scala
+++ b/src/test/scala-2.12/org/apache/james/gatling/simulation/HttpSettings.scala
@@ -2,14 +2,11 @@ package org.apache.james.gatling.simulation
 
 import io.gatling.core.Predef._
 import io.gatling.http.Predef.http
-import org.apache.james.gatling.jmap.draft.JmapHttp
 
 object HttpSettings {
 
   def httpProtocol = http
     .baseUrl(Configuration.BaseJmapUrl.toString)
-    .acceptHeader(JmapHttp.ACCEPT_JSON_VALUE)
-    .contentTypeHeader(JmapHttp.CONTENT_TYPE_JSON_VALUE)
     .wsBaseUrl(Configuration.BaseWsUrl)
 
 }


### PR DESCRIPTION
After the upgrade from Gatling 3.0.3 to 3.4.2, it seems those headers are always being injected on top (maybe before they were overrided), thus James was fetching the first one (default) and not the one overrided in the request.

Thus that creates issues with jmap-rfc simulations that rely on the Accept header to use jmap-rfc and not draft.

After scanning the code and usage, it seems safe to me to just remove those.