### PR TITLE
PushPlatformValidationScenario: exit early if some failure endanger connection state

### DIFF
--- a/src/main/scala-2.12/org/apache/james/gatling/jmap/rfc8621/scenari/PushPlatformValidationScenario.scala
+++ b/src/main/scala-2.12/org/apache/james/gatling/jmap/rfc8621/scenari/PushPlatformValidationScenario.scala
@@ -66,15 +66,15 @@ class PushPlatformValidationScenario(minMessagesInMailbox: Int,
         .exec(JmapEmail.getState()
           .check(statusOk, noError, JmapEmail.saveStateAs(emailState)))
         .exec(queryEmails(queryParameters = openpaasEmailQueryParameters(inbox))))
-      .exec(websocketConnect)
+      .exec(websocketConnect).exitHereIfFailed
       .exec(enablePush)
       .during(duration) {
         exec(ping)
           .exec(randomSwitch(
             2.0 -> inboxHomeLoading.inboxHomeLoading,
             8.0 -> selectArbitrary.selectArbitrary,
-            5.0 -> JmapEmail.submitEmails(recipientFeeder),
-            30.0 -> openArbitrary.openArbitrary,
+            5.0 -> JmapEmail.submitEmails(recipientFeeder).exitHereIfFailed,
+            30.0 -> openArbitrary.openArbitrary.exitHereIfFailed,
             10.0 -> flagUpdate,
             15.0 -> getNewState,
             30.0 -> exec())


### PR DESCRIPTION
This could help avoids the simulation hanging forever when there were some users who could not open a WebSocket connection.

I took the inspiration from: https://github.com/linagora/james-gatling/commit/c74dc647a4d64c64033f7b5563ede937a7bb5ed4, https://github.com/gatling/gatling/issues/2973#issuecomment-217806542
