### PR TITLE
Fix number of system mailboxes in Gatling JMAP simulations

### DIFF
--- a/src/main/scala-2.12/org/apache/james/gatling/jmap/draft/JmapMailbox.scala
+++ b/src/main/scala-2.12/org/apache/james/gatling/jmap/draft/JmapMailbox.scala
@@ -51,7 +51,8 @@ object JmapMailbox {
   private val draftsIdPath = s"$$$mailboxListPath[?(@.role == 'drafts')].id"
   private val trashIdPath = s"$$$mailboxListPath[?(@.role == 'trash')].id"
   private val spamIdPath = s"$$$mailboxListPath[?(@.role == 'spam')].id"
-  val numberOfSystemMailboxes = 6
+  private val archiveIdPath = s"$$$mailboxListPath[?(@.role == 'archive')].id"
+  val numberOfSystemMailboxes = 7
 
   def getMailboxes(): HttpRequestBuilder =
     JmapAuthentication.authenticatedQuery("getMailboxes", "/jmap")
@@ -91,7 +92,8 @@ object JmapMailbox {
       jsonPath(sentIdPath).is("${sentMailboxId}"),
       jsonPath(draftsIdPath).is("${draftMailboxId}"),
       jsonPath(trashIdPath).is("${trashMailboxId}"),
-      jsonPath(spamIdPath).is("${spamMailboxId}")
+      jsonPath(spamIdPath).is("${spamMailboxId}"),
+      jsonPath(archiveIdPath).is("${archiveMailboxId}")
     )
 
   def saveInboxAs(key: String): Seq[HttpCheck] = List(jsonPath(inboxIdPath).saveAs(key))
@@ -108,7 +110,8 @@ object JmapMailbox {
       jsonPath(sentIdPath).saveAs("sentMailboxId"),
       jsonPath(draftsIdPath).saveAs("draftMailboxId"),
       jsonPath(trashIdPath).saveAs("trashMailboxId"),
-      jsonPath(spamIdPath).saveAs("spamMailboxId"))
+      jsonPath(spamIdPath).saveAs("spamMailboxId"),
+      jsonPath(archiveIdPath).saveAs("archiveMailboxId"))
 
   def storeMailboxIds(): Seq[HttpCheck] = getSystemMailboxesChecks
 


### PR DESCRIPTION
After a recent update on James, the number of system mailboxes provisionned by default is 7 and not 6 anymore : 'archive' mailbox was added.