### PR TITLE
Differentiate env configuration for scenario and injection duration o…

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -14,9 +14,17 @@
 #SMTP_SSL_PORT=465
 #WEBADMIN_PROTOCOL=http
 
-# Integer value. Unit: Minutes. It provided the configure for scenario duration and injection duration.
+# Integer value. Unit: Minutes. It provided the configure for scenario and injection duration if those aren't defined.
 # Default is 60 minutes
 #DURATION=15
+
+# Integer value. Unit: Minutes. It provided the configure for scenario duration.
+# Default is 60 minutes
+#SCENARIO_DURATION=15
+
+# Integer value. Unit: Minutes. It provided the configure for injection duration.
+# Default is 60 minutes
+#INJECTION_DURATION=10
 
 # Integer value. Unit: Minutes. Force your run to terminate based on a duration limit. even if some virtual users are still running.
 # Default is 180 minutes

--- a/src/main/scala-2.13/org/apache/james/gatling/jmap/rfc8621/JmapMailbox.scala
+++ b/src/main/scala-2.13/org/apache/james/gatling/jmap/rfc8621/JmapMailbox.scala
@@ -58,7 +58,7 @@ object JmapMailbox {
   private val sentIdPath = s"$mailboxListPath[?(@.role == 'sent')].id"
   private val draftsIdPath = s"$mailboxListPath[?(@.role == 'drafts')].id"
   private val trashIdPath = s"$mailboxListPath[?(@.role == 'trash')].id"
-  private val spamIdPath = s"$mailboxListPath[?(@.role == 'spam')].id"
+  private val spamIdPath = s"$mailboxListPath[?(@.role == 'junk')].id"
   private val statePath = "$.methodResponses[0][1].state"
   private val newStatePath = "$.methodResponses[0][1].newState"
 

--- a/src/test/scala-2.13/org/apache/james/gatling/simulation/Configuration.scala
+++ b/src/test/scala-2.13/org/apache/james/gatling/simulation/Configuration.scala
@@ -28,13 +28,23 @@ object Configuration {
     case _ => None
   }
 
+  val SCENARIO_DURATION_PROPERTY = Properties.envOrNone("SCENARIO_DURATION") match {
+    case Some(duration) => Some(duration.toInt minutes)
+    case _ => DURATION_PROPERTY
+  }
+
+  val INJECTION_DURATION_PROPERTY = Properties.envOrNone("INJECTION_DURATION") match {
+    case Some(duration) => Some(duration.toInt minutes)
+    case _ => DURATION_PROPERTY
+  }
+
   val MAX_DURATION_PROPERTY = Properties.envOrNone("MAX_DURATION") match {
     case Some(duration) => Some(duration.toInt minutes)
     case _ => None
   }
 
-  val ScenarioDuration = DURATION_PROPERTY.getOrElse(1 hour)
-  val InjectionDuration = DURATION_PROPERTY.getOrElse(1 hour)
+  val ScenarioDuration = SCENARIO_DURATION_PROPERTY.getOrElse(1 hour)
+  val InjectionDuration = INJECTION_DURATION_PROPERTY.getOrElse(1 hour)
   val MaxDuration = MAX_DURATION_PROPERTY.getOrElse(3 hour)
   val UserCount = Properties.envOrElse("USER_COUNT", "100").toInt
   val RandomlySentMails = 10


### PR DESCRIPTION
…f a simulation

As we clearly dont necessary want the same duration for injection and scenario durations, having the same env variable for both makes no sense IMO.