### PR TITLE
Jmap Email/Query: sort by receievdAt

### DIFF
--- a/src/main/scala-2.13/org/apache/james/gatling/jmap/rfc8621/JmapEmail.scala
+++ b/src/main/scala-2.13/org/apache/james/gatling/jmap/rfc8621/JmapEmail.scala
@@ -52,7 +52,7 @@ object JmapEmail {
        |  "text": "$keyword"
        |},
        |"sort": [{
-       |  "property": "sentAt",
+       |  "property": "receivedAt",
        |  "isAscending": false
        |}],
        |"position": 0,
@@ -80,7 +80,7 @@ object JmapEmail {
        |  "inMailbox": "#{$mailboxKey}"
        |},
        |"sort": [{
-       |  "property": "sentAt",
+       |  "property": "receivedAt",
        |  "isAscending": false
        |}],
        |"position": 0,


### PR DESCRIPTION
sentAt projections have been dropped in James and if not changed, we hit Opensearch instead of the email query view projection

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated email sorting to use received date instead of sent date for more intuitive email organization across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->