### PR TITLE
Add email/query by keyword for jmap validation scenario

### DIFF
--- a/src/main/scala-2.13/org/apache/james/gatling/jmap/rfc8621/JmapEmail.scala
+++ b/src/main/scala-2.13/org/apache/james/gatling/jmap/rfc8621/JmapEmail.scala
@@ -60,7 +60,7 @@ object JmapEmail {
        |""".stripMargin
   }
 
-  def filterKeywordQueryParameter(keyword: String = RandomStringGenerator.randomMeaningWord()): JmapParameters = {
+  def filterKeywordQueryParameter(keyword: String = RandomStringGenerator.randomKeyword()): JmapParameters = {
     s""",
        |"filter": {
        |  "hasKeyword": "$keyword"
@@ -283,6 +283,7 @@ object JmapEmail {
                   recipient: String = "recipient",
                   subject: String = "subject",
                   textBody: String = "textBody",
+                  keyword: String = RandomStringGenerator.randomKeyword(),
                   attachmentsJsonPart: String = ""): HttpRequestBuilder =
     JmapHttp.apiCall(title.title)
       .body(StringBody(
@@ -295,6 +296,9 @@ object JmapEmail {
            |        "#{$messageId}": {
            |          "mailboxIds": {
            |            "#{$mailboxId}": true
+           |          },
+           |          "keywords":{
+           |            "$keyword": true
            |          },
            |          "subject": "#{$subject}",
            |          "from": [{"email": "#{$username}"}],

--- a/src/main/scala-2.13/org/apache/james/gatling/jmap/rfc8621/JmapEmail.scala
+++ b/src/main/scala-2.13/org/apache/james/gatling/jmap/rfc8621/JmapEmail.scala
@@ -27,8 +27,8 @@ object JmapEmail {
   val subjectSessionParam = "subject"
   val textBodySessionParam = "textBody"
 
-  def queryEmailsAndCheck(queryParameters: JmapParameters = NO_PARAMETERS): ChainBuilder =
-    exec(queryEmails(queryParameters)
+  def queryEmailsAndCheck(callName: String = "emailQuery", queryParameters: JmapParameters = NO_PARAMETERS): ChainBuilder =
+    exec(queryEmails(callName, queryParameters)
       .check(JmapHttp.statusOk, JmapHttp.noError))
 
   def queryEmails(callName: String = "emailQuery", queryParameters: JmapParameters = NO_PARAMETERS): HttpRequestBuilder = {
@@ -46,10 +46,24 @@ object JmapEmail {
            |}""".stripMargin))
   }
 
-  def filterKeywordQueryParameter(keyword: String = RandomStringGenerator.randomMeaningWord()): JmapParameters = {
+  def filterTextQueryParameter(keyword: String = RandomStringGenerator.randomMeaningWord()): JmapParameters = {
     s""",
        |"filter": {
        |  "text": "$keyword"
+       |},
+       |"sort": [{
+       |  "property": "receivedAt",
+       |  "isAscending": false
+       |}],
+       |"position": 0,
+       |"limit": 30
+       |""".stripMargin
+  }
+
+  def filterKeywordQueryParameter(keyword: String = RandomStringGenerator.randomMeaningWord()): JmapParameters = {
+    s""",
+       |"filter": {
+       |  "hasKeyword": "$keyword"
        |},
        |"sort": [{
        |  "property": "receivedAt",

--- a/src/main/scala-2.13/org/apache/james/gatling/jmap/rfc8621/scenari/EmailQueryScenario.scala
+++ b/src/main/scala-2.13/org/apache/james/gatling/jmap/rfc8621/scenari/EmailQueryScenario.scala
@@ -16,7 +16,7 @@ class EmailQueryScenario {
       .exec(JmapMailbox.provisionUsersWithMessages(recipientFeeder, numberOfMessages = 10))
       .exec(SessionStep.retrieveAccountId)
       .during(duration.toSeconds.toInt) {
-        exec(JmapEmail.queryEmails(JmapEmail.filterKeywordQueryParameter())
+        exec(JmapEmail.queryEmails(queryParameters = JmapEmail.filterTextQueryParameter())
           .check(JmapHttp.statusOk, JmapHttp.noError))
           .pause(1 second)
       }

--- a/src/main/scala-2.13/org/apache/james/gatling/jmap/rfc8621/scenari/JmapPlatformValidationScenario.scala
+++ b/src/main/scala-2.13/org/apache/james/gatling/jmap/rfc8621/scenari/JmapPlatformValidationScenario.scala
@@ -68,14 +68,15 @@ class JmapPlatformValidationScenario (minMessagesInMailbox: Int,
       .during(duration.toSeconds.toInt) {
         exec(randomSwitch(
           2.0 -> inboxHomeLoading.inboxHomeLoading,
-          2.0 -> JmapEmail.queryEmailsAndCheck(JmapEmail.filterKeywordQueryParameter()),
+          2.0 -> JmapEmail.queryEmailsAndCheck(queryParameters = JmapEmail.filterTextQueryParameter()),
+          2.0 -> JmapEmail.queryEmailsAndCheck("keywordQuery", JmapEmail.filterKeywordQueryParameter()),
           3.0 -> exec(JmapEmail.performMove()),
           5.0 -> JmapEmail.submitEmails(recipientFeeder),
           8.0 -> selectArbitrary.selectArbitrary,
           25.0 -> openArbitrary.openArbitrary,
           10.0 -> flagUpdate,
           15.0 -> getNewState,
-          30.0 -> exec(List.empty))
+          28.0 -> exec(List.empty))
           .asInstanceOf[ChainBuilder]
           .pause(minWaitDelay, maxWaitDelay))
       }

--- a/src/main/scala-2.13/org/apache/james/gatling/jmap/rfc8621/scenari/PushPlatformValidationScenario.scala
+++ b/src/main/scala-2.13/org/apache/james/gatling/jmap/rfc8621/scenari/PushPlatformValidationScenario.scala
@@ -76,7 +76,7 @@ class PushPlatformValidationScenario(minMessagesInMailbox: Int,
         exec(ping)
           .exec(randomSwitch(
             2.0 -> inboxHomeLoading.inboxHomeLoading,
-            2.0 -> JmapEmail.queryEmailsAndCheck(JmapEmail.filterKeywordQueryParameter()),
+            2.0 -> JmapEmail.queryEmailsAndCheck(queryParameters = JmapEmail.filterTextQueryParameter()),
             3.0 -> exec(JmapEmail.performMove()),
             5.0 -> JmapEmail.submitEmails(recipientFeeder),
             8.0 -> selectArbitrary.selectArbitrary,

--- a/src/main/scala-2.13/org/apache/james/gatling/utils/RandomStringGenerator.scala
+++ b/src/main/scala-2.13/org/apache/james/gatling/utils/RandomStringGenerator.scala
@@ -10,6 +10,19 @@ object RandomStringGenerator {
 
   val faker: Faker = new Faker()
 
+  val keywords: List[String] = List(
+    "keyword0",
+    "keyword1",
+    "keyword2",
+    "keyword3",
+    "keyword4",
+    "keyword5",
+    "keyword6",
+    "keyword7",
+    "keyword8",
+    "keyword9"
+  )
+
   def randomString: String = UUID.randomUUID().toString
 
   def randomAlphaString(length: Int = 5): String = Random.alphanumeric.take(length).mkString("")
@@ -30,4 +43,8 @@ object RandomStringGenerator {
 
   def randomDomain: String = faker.internet().domainName()
 
+  def randomKeyword(): String = {
+    val index: Int = faker.random().nextInt(0, 9).toInt
+    keywords(index)
+  }
 }


### PR DESCRIPTION
I dont thnk a random word for keyword has much sense here. Opened to suggestions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an explicit keyword-based email filter and preserved existing text-based filtering; default sorting and pagination unchanged.
  * Submit-email now accepts an optional keyword (defaults to a random one).
  * Query operations can be invoked with an optional operation name for clearer tracing.

* **Tests**
  * Validation scenarios updated to exercise both text- and keyword-based queries and adjusted branch weights to include a dedicated keyword-query path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->