### PR TITLE
Increase IMAP/JMAP message size

### DIFF
--- a/src/main/scala-2.13/org/apache/james/gatling/imap/scenari/ImapCommonSteps.scala
+++ b/src/main/scala-2.13/org/apache/james/gatling/imap/scenari/ImapCommonSteps.scala
@@ -9,6 +9,11 @@ import com.linagora.gatling.imap.protocol.command.MessageRanges
 import io.gatling.core.Predef._
 
 object ImapCommonSteps {
+  private val CompressionPaddingRepeatCount = 150
+  // Adds 17 KB to the fixed IMAP MIME payload, making appended mails around 22 KB.
+  private val compressionPadding =
+    "Compression threshold padding for Gatling IMAP payload. Lorem ipsum dolor sit amet, consectetur adipiscing elit.\n" * CompressionPaddingRepeatCount
+
   val receiveEmail = exec(imap("append").append("INBOX", Some(scala.collection.immutable.Seq("\\Flagged")), Option.empty[Calendar],
     """Return-Path: expeditor@linagora.com>
       |Delivered-To: ${username}
@@ -73,7 +78,7 @@ object ImapCommonSteps {
       |aliquam quis. Aliquam feugiat tempus risus. Suspendisse non tellus condimentum, molestie sapien vitae, consequat
       |turpis. Etiam efficitur, odio non blandit scelerisque, leo est aliquet turpis, a condimentum lectus quam vel
       |ipsum. Nam fringilla eros vitae sodales laoreet.
-      |""".stripMargin).check(ok))
+      |""".stripMargin + compressionPadding).check(ok))
 
   val readLastEmail = exec(imap("list").list("", "*").check(ok, hasFolder("INBOX")))
     .exec(imap("select").select("INBOX").check(ok))

--- a/src/main/scala-2.13/org/apache/james/gatling/jmap/rfc8621/JmapEmail.scala
+++ b/src/main/scala-2.13/org/apache/james/gatling/jmap/rfc8621/JmapEmail.scala
@@ -22,6 +22,11 @@ case class KeywordName(name: String) extends AnyVal
 object JmapEmail {
   type JmapParameters = String
   val NO_PARAMETERS : JmapParameters = ""
+  private val CompressionCandidateBodyRepeatCount = 190
+  // Generates a 21.7 KB compressible body
+  def compressionCandidateBody: String =
+    s"${RandomStringGenerator.randomString}\n" +
+      "Compression threshold padding for Gatling JMAP payload. Lorem ipsum dolor sit amet, consectetur adipiscing elit.\n" * CompressionCandidateBodyRepeatCount
 
   val messageIdSessionParam = "messageId"
   val subjectSessionParam = "subject"
@@ -256,7 +261,7 @@ object JmapEmail {
     val mailFeeder = Iterator.continually(
       Map(messageIdSessionParam -> MessageId().id,
         subjectSessionParam -> Subject().subject,
-        textBodySessionParam -> TextBody().text))
+        textBodySessionParam -> compressionCandidateBody))
 
     feed(mailFeeder)
       .feed(recipientFeeder)

--- a/src/main/scala-2.13/org/apache/james/gatling/jmap/rfc8621/JmapEmail.scala
+++ b/src/main/scala-2.13/org/apache/james/gatling/jmap/rfc8621/JmapEmail.scala
@@ -25,8 +25,8 @@ object JmapEmail {
   private val CompressionCandidateBodyRepeatCount = 190
   // Generates a 21.7 KB compressible body
   def compressionCandidateBody: String =
-    s"${RandomStringGenerator.randomString}\n" +
-      "Compression threshold padding for Gatling JMAP payload. Lorem ipsum dolor sit amet, consectetur adipiscing elit.\n" * CompressionCandidateBodyRepeatCount
+    s"${RandomStringGenerator.randomString} " +
+      "Compression threshold padding for Gatling JMAP payload. Lorem ipsum dolor sit amet, consectetur adipiscing elit. " * CompressionCandidateBodyRepeatCount
 
   val messageIdSessionParam = "messageId"
   val subjectSessionParam = "subject"


### PR DESCRIPTION
To exceed the 16KB threshold of compression blob store.

 Before:

  - IMAP receiveEmail appended a fixed MIME message of about 4.97 KB.
  - JMAP submitEmails generated a tiny body from TextBody().text, effectively a UUID string of 36 bytes before MIME overhead.

  After:

  - IMAP receiveEmail appends the same fixed MIME message plus 17 KB of compressible padding, making each appended mail about 22 KB.
  - JMAP submitEmails generates a body with:
      - one random UUID prefix to avoid identical blobs,
      - 21.66 KB of repeated compressible text, - total body about 21.7 KB before MIME overhead.